### PR TITLE
fix: kdns_tcp structure init in dns_tcp_process thread, but main thread maybe use it before initialized

### DIFF
--- a/kdns/src/kdns-adap.c
+++ b/kdns/src/kdns-adap.c
@@ -22,7 +22,7 @@ struct kdns dpdk_dns[MAX_CORES];
 extern void domain_store_zones_check_create(struct kdns*  kdns, char *zones);
 
 
-static int dnsdata_prepare(struct kdns * kdns) {
+int dnsdata_prepare(struct kdns * kdns) {
     if (( kdns->db = domain_store_open()) == NULL) {
         log_msg(LOG_ERR,"unable to open the database \n");
         exit(-1);

--- a/kdns/src/kdns-adap.h
+++ b/kdns/src/kdns-adap.h
@@ -5,7 +5,7 @@
 #include "kdns.h"
 #include "util.h"
 
-
+int dnsdata_prepare(struct kdns * kdns);
 int kdns_init(unsigned lcore_id);
 
 kdns_query_st* dns_packet_proess(struct rte_mbuf *pkt ,uint32_t sip, int offset, int received); 

--- a/kdns/src/tcp_process.c
+++ b/kdns/src/tcp_process.c
@@ -118,19 +118,6 @@ static void *dns_tcp_process(void *arg) {
     int sock_descriptor,temp_sock_descriptor,address_size;  
     char buf[16384]; 
 
-
-    memset(&kdns_tcp,0,sizeof(kdns_tcp));
-
-    if (( kdns_tcp.db = domain_store_open()) == NULL) {
-        log_msg(LOG_ERR,"unable to open the database \n");
-        exit(-1);
-    } 
-
-    domain_store_zones_check_create( &kdns_tcp,g_dns_cfg->comm.zones);
-
-    kdns_zones_soa_create( kdns_tcp.db,g_dns_cfg->comm.zones);
-
-
     query_tcp = query_create();
     
     sleep(30);
@@ -151,7 +138,6 @@ static void *dns_tcp_process(void *arg) {
         exit(1);  
     }  
     printf("Accpting connections...\n");  
-
 
     while(1)  
     {  
@@ -213,6 +199,11 @@ static void *dns_tcp_process(void *arg) {
 }  
 
 int dns_tcp_process_init(char *ip){
+    memset(&kdns_tcp,0,sizeof(kdns_tcp));
+    if (dnsdata_prepare(&kdns_tcp) != 0) {
+        log_msg(LOG_ERR,"server preparation failed,could not be started");
+        return -1;
+    }
 
     pthread_t *thread_cache_expired = (pthread_t *)  xalloc(sizeof(pthread_t));  
     pthread_create(thread_cache_expired, NULL, dns_tcp_process, (void*)ip);


### PR DESCRIPTION
(gdb) bt full
#0  0x000000000045483c in domain_store_find_zone (db=0x0, dname=0x1299840) at /media/disk1/fordata/jenkins/workspace/kdns_build_upload/default/core/domain_store.c:464
        n = 0x0
#1  0x0000000000446823 in domaindata_a_insert (db=0x0, zone_name=0x129b14c "yz02.", domain_name=0x129b1cc "sd-bjpg-c955.yz02.", view_name=0x129b04c "no_info", ip_addr=0x129b24c "10.62.107.18", ttl=86400, maxAnswer=0)
    at /media/disk1/fordata/jenkins/workspace/kdns_build_upload/default/src/db_update.c:452
        zname = 0x1299840
        dname = 0x1299ab0
        zo = 0x1ffe0
        rr_insert = 0x7ffc4a86b4b0
        dataA = 0x7fe2b1e01760 <main_arena>
        rrset = 0x7ffc4a860000
#2  0x0000000000446b8a in domaindata_update (db=0x0, update=0x129b030) at /media/disk1/fordata/jenkins/workspace/kdns_build_upload/default/src/db_update.c:518
No locals.
#3  0x000000000044f47b in tcp_domian_databd_update (update=0x129b030) at /media/disk1/fordata/jenkins/workspace/kdns_build_upload/default/src/tcp_process.c:42
No locals.
#4  0x000000000044887f in doman_msg_master_process () at /media/disk1/fordata/jenkins/workspace/kdns_build_upload/default/src/domain_update.c:209
        new_msg_tcp = 0x129b030
        msg = 0x7fe224000d90
        cid_master = 1
        idx = 64
#5  0x0000000000451e55 in process_master (arg=0x0) at /media/disk1/fordata/jenkins/workspace/kdns_build_upload/default/src/process.c:323
        rx_count = 0
        fwd_pkts_tx = {0x240, 0x1298c70, 0x0, 0x7fe2b2984e6e <_dl_allocate_tls_init+270>, 0x1298c90, 0x7fe251bf6700, 0x7fe2b2b94000 <_rtld_local>, 0x7fe2b2555f7a <do_clone.constprop.4+74>, 0x7fe251bf69d0, 
          0x7fe2b2b94000 <_rtld_local>, 0x0, 0x7fe2b276a3e0 <__default_pthread_attr>, 0x7fe2b2b94000 <_rtld_local>, 0x7fe2b2557469 <pthread_create@@GLIBC_2.2.5+1065>, 0x43b780 <_start>, 0x1000, 0x300000008, 0x0, 
          0x44f7c0 <dns_tcp_process>, 0x1150290, 0xa01000 <g_fwd_cache_hash_list+1112640>, 0x7fe2b1ac6fbc <malloc+76>, 0x1298c60, 0x7fe2511f6000, 0x7ffc4a86b9c0, 0x0, 0x7ffc4a86b9f0, 0x43b780 <_start>, 0x7ffc4a86bb00, 0x0, 0x0, 
          0x44fc1d <dns_tcp_process_init+55>}
        fwd_count = 0
        pkts_kni_rx = {0x30312e3834002e61, 0x726464612d6e692e, 0x35002e617072612e, 0x2d6e692e30312e30, 0x7072612e72646461, 0x30312e3235002e61, 0x726464612d6e692e, 0x35002e617072612e, 0x2d6e692e30312e34, 0x7072612e72646461, 
          0x30312e3635002e61, 0x726464612d6e692e, 0x35002e617072612e, 0x2d6e692e30312e38, 0x7072612e72646461, 0x30312e3036002e61, 0x726464612d6e692e, 0x36002e617072612e, 0x2d6e692e30312e32, 0x7072612e72646461, 0x30312e3037002e61, 
          0x726464612d6e692e, 0x37002e617072612e, 0x2d6e692e30312e31, 0x7072612e72646461, 0x30312e3237002e61, 0x726464612d6e692e, 0x7fe2b1e017b0 <main_arena+80>, 0xffff8003b5794811, 0x7ffc4a86b7f0, 0x7ffc4a86b7ef, 
          0x726464612d6e692e}
        pkt_num = 0
        kni_pkts_tx = {0x37002e617072612e, 0x2d6e692e30312e35, 0x7072612e72646461, 0x30312e3038002e61, 0x726464612d6e692e, 0x39002e617072612e, 0x2d6e692e30312e30, 0x7072612e72646461, 0xffff8003b5794771, 0x7fe200000025, 0x9, 0x1, 
          0x5c00000039, 0x7ffc4a86b890, 0x0, 0x0, 0x770000006e, 0x0, 0x7ffc4a86b88f, 0x0, 0x5b00000034, 0x7ffc4a86b8d0, 0x7c, 0x0, 0x770000006e, 0x0, 0xffff8003b57946e1, 0x2, 0x0, 0x7fe2b1e01760 <main_arena>, 0x22, 0x1390}
        npkts = 0
#6  0x000000000043be45 in main (argc=1, argv=0x7ffc4a86bb08) at /media/disk1/fordata/jenkins/workspace/kdns_build_upload/default/src/main.c:158
        lcore_id = 128
(gdb) 