### PR TITLE
set main process affinity to master core and fix thread name

### DIFF
--- a/kdns/src/forward.c
+++ b/kdns/src/forward.c
@@ -307,7 +307,7 @@ int remote_sock_init(char * fwd_addrs, char * fwd_def_addr,int fwd_threads){
     // cache date expired clean up thread
     pthread_t *thread_cache_expired = (pthread_t *)  xalloc(sizeof(pthread_t));  
     pthread_create(thread_cache_expired, NULL, thread_fwd_cache_expired_cleanup, (void*)NULL);
-    pthread_setname_np(*thread_cache_expired, "kdns_fwd_cache");
+    pthread_setname_np(*thread_cache_expired, "kdns_fcache_clr");
  
     return 0;
 }

--- a/kdns/src/main.c
+++ b/kdns/src/main.c
@@ -117,6 +117,7 @@ static void init_signals(void)
 	sigaction(SIGUSR2, &sigact, NULL);
 }
 
+//set thread's affinity to cpus that are not used by dpdk
 static int set_thread_affinity(void)
 {
     int s;

--- a/kdns/src/metrics.c
+++ b/kdns/src/metrics.c
@@ -317,19 +317,19 @@ void fwd_metrics_init(void){
     // cache date expired clean up thread
     pthread_t *thread_cache_expired = (pthread_t *)  xalloc(sizeof(pthread_t));  
     pthread_create(thread_cache_expired, NULL, thread_metrics_expired_cleanup, (void*)NULL);
-    pthread_setname_np(*thread_cache_expired, "metrics_cleanup");
+    pthread_setname_np(*thread_cache_expired, "kdns_mcache_clr");
 
    // sleep(3);
 
     // metrics_domains thread
     pthread_t *thread_domain_metrics = (pthread_t *)  xalloc(sizeof(pthread_t));  
     pthread_create(thread_domain_metrics, NULL, thread_metrics_domain_getAll, (void*)NULL);
-    pthread_setname_np(*thread_domain_metrics, "metrics_domains");
+    pthread_setname_np(*thread_domain_metrics, "kdns_domain_get");
 
     // metrics_domains_clientIp thread
     pthread_t *thread_domain_clientIp_metrics = (pthread_t *)  xalloc(sizeof(pthread_t));  
     pthread_create(thread_domain_clientIp_metrics, NULL, thread_metrics_domain_clientIp_getAll, (void*)NULL);
-    pthread_setname_np(*thread_domain_clientIp_metrics, "metrics_domains_clientIp");
+    pthread_setname_np(*thread_domain_clientIp_metrics, "kdns_cip_get");
 } 
 
 

--- a/kdns/src/netdev.c
+++ b/kdns/src/netdev.c
@@ -113,7 +113,7 @@ static void check_all_ports_link_status(uint8_t port_num, uint32_t port_mask)
 	uint8_t portid, count, all_ports_up, print_flag = 0;
 	struct rte_eth_link link;
 
-	log_msg(LOG_INFO,"\nChecking link status\n");
+	log_msg(LOG_INFO,"Checking link status\n");
 	fflush(stdout);
 	for (count = 0; count <= MAX_CHECK_TIME; count++) {
 		all_ports_up = 1;


### PR DESCRIPTION
1.set main process affinity to master core
2.thread name length is restricted to 16 characters, including the terminating null byte ('\0')