### PR TITLE
Optimized reload implementation

### DIFF
--- a/kdns/src/dns-conf.c
+++ b/kdns/src/dns-conf.c
@@ -579,7 +579,6 @@ int config_reload_proc(char* dns_cfgfile)
     if (!g_dns_cfg || !g_reload_dns_cfg)
         return 0;
 
-    domain_set_kdns_status(DNS_STATUS_INIT);
     ret = config_log_file_reload_proc();
     if (ret)
         return ret;
@@ -597,6 +596,5 @@ int config_reload_proc(char* dns_cfgfile)
         return ret;
 
     config_reload_free();
-    domain_set_kdns_status(DNS_STATUS_RUN);
     return 0;
 }

--- a/kdns/src/domain_update.c
+++ b/kdns/src/domain_update.c
@@ -160,14 +160,6 @@ void domain_list_del_zone(char *zones)
     }
 }
 
-void domain_set_kdns_status(const char *status)
-{
-    if (kdns_status) {
-        free(kdns_status);
-    }
-    kdns_status = strdup(status);
-}
-
 // to optimization
 static void domain_info_store(struct domin_info_update *msg)
 {

--- a/kdns/src/forward.h
+++ b/kdns/src/forward.h
@@ -3,6 +3,8 @@
 #ifndef	_FORWARD_H_
 #define	_FORWARD_H_
 
+#define _GNU_SOURCE
+#include <pthread.h>
 #include <rte_mbuf.h>
 #include <arpa/inet.h>
 #include <rte_rwlock.h>
@@ -11,7 +13,7 @@
 
 #define FWD_MAX_DOMAIN_NAME_LEN  255
 
-extern rte_rwlock_t __fwd_lock;
+extern pthread_rwlock_t __fwd_lock;
 
 
 typedef struct {

--- a/kdns/src/tcp_process.c
+++ b/kdns/src/tcp_process.c
@@ -115,7 +115,7 @@ static int dns_handle_tcp_remote(int respond_sock, char *snd_pkt, uint16_t old_i
     char recv_buf[TCP_MAX_MESSAGE_LEN] = {0};
 
     tcp_stats.dns_fwd_rcv_tcp++;
-    rte_rwlock_read_lock(&__fwd_lock);
+    pthread_rwlock_rdlock(&__fwd_lock);
     domain_fwd_addrs *fwd_addrs = find_zone_fwd_addrs(domain);
     for (;i < fwd_addrs->servers_len; i++){
         retfwd = dns_do_remote_tcp_query(snd_pkt, snd_len, recv_buf, TCP_MAX_MESSAGE_LEN, &fwd_addrs->server_addrs[i]);
@@ -132,7 +132,7 @@ static int dns_handle_tcp_remote(int respond_sock, char *snd_pkt, uint16_t old_i
         }
     }
 
-    rte_rwlock_read_unlock(&__fwd_lock);
+    pthread_rwlock_unlock(&__fwd_lock);
     if (retfwd > 0){
         if(send(respond_sock,recv_buf,retfwd,0) == -1){   
             log_msg(LOG_ERR,"last send error %s\n", domain);


### PR DESCRIPTION
1.remove unnecessary kdns status changes
2.fix memory leaks cause by reload
3.prevent writer starvation in a read write lock in forward